### PR TITLE
Add libndtypes and ndtypes-python.

### DIFF
--- a/content/pages/projects/libndtypes.md
+++ b/content/pages/projects/libndtypes.md
@@ -1,0 +1,5 @@
+Title: Libndtypes
+Project: core
+Category: Projects
+Subtitle: A C/C++ library for a low-level version of Datashape
+Docs: http://libndtypes.readthedocs.org/en/latest/index.html

--- a/content/pages/projects/ndtypes-python.md
+++ b/content/pages/projects/ndtypes-python.md
@@ -1,0 +1,5 @@
+Title: Ndtypes-python
+Project: core
+Category: Projects
+Subtitle: Python bindings for libndtypes
+Docs: http://ndtypes-python.readthedocs.org/en/latest/index.html


### PR DESCRIPTION

This adds links to the libndtypes and ndtypes-python docs to the front page. 